### PR TITLE
ci: run `semantic-release` twice

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -27,16 +27,14 @@ jobs:
       contents: write
     steps:
       - uses: actions/checkout@v4
-      - uses: codfish/semantic-release-action@v2
+      - uses: codfish/semantic-release-action@v3
+        # First run `semantic-release` to analyze whether a release is required
         id: sem-rel
         with:
           branches: |
             ["main"]
           plugins: |
-            [ "@semantic-release/commit-analyzer",
-              "@semantic-release/release-notes-generator",
-              "@semantic-release/github"
-            ]
+            [ "@semantic-release/commit-analyzer" ]
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   build-images:
@@ -58,9 +56,23 @@ jobs:
     name: Collect results
     needs:
       - build-images
+    permissions:
+      contents: write
     runs-on: ubuntu-latest
     steps:
-      - run: echo "Builds succeeded!"
+      - uses: actions/checkout@v4
+      - uses: codfish/semantic-release-action@v3
+        id: sem-rel
+        with:
+          branches: |
+            ["main"]
+          plugins: |
+            [ "@semantic-release/commit-analyzer",
+              "@semantic-release/release-notes-generator",
+              "@semantic-release/github"
+            ]
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Update Healthchecks.io
         if: github.ref == format('refs/heads/{0}', github.event.repository.default_branch)
         run: curl -fsS -m 10 --retry 5 -o /dev/null https://hc-ping.com/${HC_UUID}


### PR DESCRIPTION
* once is an "analyse" run to see whether a release is required
* then, after a successful Docker build & release workflow
